### PR TITLE
add driver/ubiquity using paramiko

### DIFF
--- a/etc/lavapdu/lavapdu.conf
+++ b/etc/lavapdu/lavapdu.conf
@@ -28,6 +28,13 @@
         },
         "192.168.25.52": {
             "driver": "apc7952"
-        }
+        },
+	"192.168.154.173": {
+		"driver": "ubntmfi3port",
+		"username": "ubnt",
+		"password": "ubnt",
+		"sshport": 22,
+		"verify_hostkey": true
+	}
     }
 }

--- a/lavapdu/drivers/strategies.py
+++ b/lavapdu/drivers/strategies.py
@@ -22,8 +22,11 @@ from lavapdu.drivers.apc7952 import APC7952  # pylint: disable=W0611
 from lavapdu.drivers.apc9218 import APC9218  # pylint: disable=W0611
 from lavapdu.drivers.apc8959 import APC8959  # pylint: disable=W0611
 from lavapdu.drivers.apc9210 import APC9210  # pylint: disable=W0611
+from lavapdu.drivers.ubiquity import Ubiquity3Port, Ubiquity6Port # pylint: disable=W0611
 
 assert APC7952
 assert APC9218
 assert APC8959
 assert APC9210
+assert Ubiquity3Port
+assert Ubiquity6Port

--- a/lavapdu/drivers/ubiquity.py
+++ b/lavapdu/drivers/ubiquity.py
@@ -1,0 +1,116 @@
+#! /usr/bin/python
+
+#  Copyright 2015 Alexander Couzens <lynxis@fe80.eu>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+
+import logging
+from paramiko import SSHClient
+from paramiko.ssh_exception import SSHException
+from paramiko import RejectPolicy, WarningPolicy
+from lavapdu.drivers.driver import PDUDriver
+log = logging.getLogger(__name__)
+
+class UbiquityBase(PDUDriver):
+    client = None
+    # overwrite power_count
+    port_count = 0
+
+    def __init__(self, hostname, settings):
+        self.hostname = hostname
+        log.debug(settings)
+        self.settings = settings
+
+        self.sshport = 22
+        self.username = "ubnt"
+        self.password = "ubnt"
+
+        # verify ssh hostkey? unknown hostkey will make this job fail
+        self.verify_hostkey = True
+
+        if "sshport" in settings:
+            self.sshport = settings["sshport"]
+        if "username" in settings:
+            self.username = settings["username"]
+        if "password" in settings:
+            self.password = settings["password"]
+        if "verify_hostkey" in settings:
+            self.verify_hostkey = settings["verify_hostkey"]
+        self.connect()
+
+        super(UbiquityBase, self).__init__()
+
+    def connect(self):
+        log.info("Connecting to Ubiquity mfi %s@%s:%d",
+                 self.username, self.hostname, self.sshport)
+        self.client = SSHClient()
+        self.client.load_system_host_keys()
+
+        if self.verify_hostkey:
+            self.client.set_missing_host_key_policy(RejectPolicy())
+        else:
+            self.client.set_missing_host_key_policy(WarningPolicy())
+
+        self.client.connect(hostname=self.hostname, port=self.sshport,
+                            username=self.username, password=self.password)
+
+    def port_interaction(self, command, port_number):
+        log.debug("Running port_interaction from UbiquityBase")
+        if port_number > self.port_count:
+            raise RuntimeError("We only have ports 1 - %d. %d > maxPorts (%d)"
+                               % self.port_count, port_number, self.port_count)
+
+        if command == "on":
+            command = "sh -c 'echo 1 > /proc/power/relay%d'" % port_number
+        elif command == "off":
+            command = "sh -c 'echo 0 > /proc/power/relay%d'" % port_number
+
+        try:
+            stdin, stdout, stderr = self.client.exec_command(command, bufsize=-1, timeout=3)
+            stdin.close()
+        except SSHException:
+            pass
+
+    def _cleanup(self):
+        self.client.close()
+
+    def _bombout(self):
+        self.client.close()
+
+    @classmethod
+    def accepts(cls, drivername):
+        log.debug(drivername)
+        return False
+
+class Ubiquity3Port(UbiquityBase):
+    port_count = 3
+
+    @classmethod
+    def accepts(cls, drivername):
+        log.debug(drivername)
+        if drivername == "ubntmfi3port":
+            return True
+        return False
+
+class Ubiquity6Port(UbiquityBase):
+    port_count = 6
+
+    @classmethod
+    def accepts(cls, drivername):
+        log.debug(drivername)
+        if drivername == "ubntmfi6port":
+            return True
+        return False

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     install_requires=[
         "daemon",
         "lockfile",
+        "paramiko",
         "pexpect",
         "psycopg2",
         "setproctitle"


### PR DESCRIPTION
ubiquity is providing 2 different drivers:
ubntmfi3port
ubntmfi6port

a small configuration is
    "pdus": {
        "192.168.154.173": {
            "driver": "ubntmfi3port"
         }
    }
Or a full blown configuration, the fields are filled with their default
values.

    "pdus": {
        "192.168.154.173": {
            "driver": "ubntmfi3port",
            "username": "ubnt",
            "password": "ubnt",
            "sshport": 22
            "verify_hostkey": true
        }
    }

Connecting to ubnt mfi is done via ssh using paramiko. Paramiko will use
a ssh-key over user/password. So no problem when using ssh keys. If verify_hostkey is enabled, you must do the first connect via ssh to the station:
`ssh 192.168.42.23` and answer the knownhost yes if the hostkey match.

Signed-off-by: Alexander Couzens <lynxis@fe80.eu>