### PR TITLE
drivers: ACME: add support for baylibre-ACME switches and power monitors

### DIFF
--- a/etc/lavapdu/lavapdu.conf
+++ b/etc/lavapdu/lavapdu.conf
@@ -10,7 +10,7 @@
         "logging_level": "INFO"
     },
     "pdus": {
-        "acme0.local": {
+        "baylibre-acme.local": {
             "driver": "acme"
         },
         "192.168.10.2": {

--- a/etc/lavapdu/lavapdu.conf
+++ b/etc/lavapdu/lavapdu.conf
@@ -10,6 +10,9 @@
         "logging_level": "INFO"
     },
     "pdus": {
+        "acme0.local": {
+            "driver": "acme"
+        },
         "192.168.10.2": {
             "driver": "apc9210"
         },

--- a/lavapdu/drivers/acme.py
+++ b/lavapdu/drivers/acme.py
@@ -1,0 +1,63 @@
+#! /usr/bin/python
+
+#  Copyright 2015 BayLibre SAS
+#  Author Marc Titinger <mtitinger@baylibre.com>
+#
+#  Based on apcxxx:
+#     Copyright 2013 Linaro Limited
+#     Author Matt Hart <matthew.hart@linaro.org>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+
+import logging
+from lavapdu.drivers.acmebase import ACMEBase
+log = logging.getLogger(__name__)
+
+
+class ACME(ACMEBase):
+
+    cmd = {'on': 'dut-switch-on', 'off': 'dut-switch-off', 'reboot': 'dut-hard-reset'}
+
+    @classmethod
+    def accepts(cls, drivername):
+        if drivername == "acme":
+            return True
+        return False
+
+    def _pdu_logout(self):
+        self._back_to_main()
+        log.debug("Logging out")
+        self.connection.send("exit\r")
+
+    def _back_to_main(self):
+        self.connection.send("\r")
+        self.connection.expect('#')
+
+    def _enter_outlet(self, outlet, enter_needed=True):
+        log.debug("Finished entering outlet (nop)")
+
+    def _port_interaction(self, command, port_number):
+        if not self.cmd.has_key(command):
+            acme_command = 'echo "unknown command {}"'.format(command)
+        else:
+            acme_command = '{} {}'.format(self.cmd[command], port_number)
+        log.debug("Attempting command: %s", acme_command)
+        self.connection.send(acme_command)
+        self._do_it()
+        self.connection.expect("#")
+
+    def _do_it(self):
+        self.connection.send("\r")

--- a/lavapdu/drivers/acmebase.py
+++ b/lavapdu/drivers/acmebase.py
@@ -1,0 +1,81 @@
+#! /usr/bin/python
+
+#  Copyright 2015 BayLibre SAS
+#  Author Marc Titinger <mtitinger@baylibre.com>
+#
+#  Based on ACPBase:
+#     Copyright 2013 Linaro Limited
+#     Author Matt Hart <matthew.hart@linaro.org>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+
+import logging
+import pexpect
+from lavapdu.drivers.driver import PDUDriver
+log = logging.getLogger(__name__)
+
+# SSH connection, assuming the id_rsa.pub key for the owner of lavapdu-runner
+# i.e. root, was added to the authorized_keys on the ACME device.
+# This may be changed to a simple telnet connection in the future.
+
+class ACMEBase(PDUDriver):
+    connection = None
+
+    def __init__(self, hostname, settings):
+        self.hostname = hostname
+        log.debug(settings)
+        self.settings = settings
+        self.username = "root"
+        if "username" in settings:
+            username = settings["username"]
+        self.exec_string = "/usr/bin/ssh %s@%s" % (self.username, hostname)
+        self.get_connection()
+        super(ACMEBase, self).__init__()
+
+    @classmethod
+    def accepts(cls, drivername):
+        log.debug(drivername)
+        return False
+
+    def port_interaction(self, command, port_number):
+        log.debug("Running port_interaction from ACMEBase")
+        self._port_interaction(command,  # pylint: disable=no-member
+                               port_number)
+
+    def get_connection(self):
+        log.debug("Connecting to Baylibre ACME with: %s", self.exec_string)
+        # only uncomment this line for FULL debug when developing
+        #self.connection = pexpect.spawn(self.exec_string, logfile=sys.stdout)
+        self.connection = pexpect.spawn(self.exec_string)
+        self._pdu_login(self.username, "")
+
+    def _cleanup(self):
+        self._pdu_logout()  # pylint: disable=no-member
+
+    def _bombout(self):
+        log.debug("Bombing out of driver: %s", self.connection)
+        self.connection.close(force=True)
+        del self
+
+    def _pdu_login(self, username, password):
+        log.debug("attempting login with username %s, password %s",
+                  username, password)
+        index = self.connection.expect(['#', 'password', 'yes/no'])
+        if index == 1:
+            self.connection.send("%s\r" % password)
+        elif index == 2:
+            self.connection.send("yes\r")
+

--- a/lavapdu/drivers/strategies.py
+++ b/lavapdu/drivers/strategies.py
@@ -18,6 +18,7 @@
 #  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 #  MA 02110-1301, USA.
 
+from lavapdu.drivers.acme import ACME  # pylint: disable=W0611
 from lavapdu.drivers.apc7952 import APC7952  # pylint: disable=W0611
 from lavapdu.drivers.apc9218 import APC9218  # pylint: disable=W0611
 from lavapdu.drivers.apc8959 import APC8959  # pylint: disable=W0611
@@ -25,6 +26,7 @@ from lavapdu.drivers.apc9210 import APC9210  # pylint: disable=W0611
 from lavapdu.drivers.ubiquity import Ubiquity3Port  # pylint: disable=W0611
 from lavapdu.drivers.ubiquity import Ubiquity6Port  # pylint: disable=W0611
 
+assert ACME
 assert APC7952
 assert APC9218
 assert APC8959


### PR DESCRIPTION
ACME is a modular hardware interface to switch and measure supply
voltage/current/power of Devices Under Test (DUT).
currently it is available as an extension cape for BeagleBone-Black (BBB).

This proposed driver runs the pdudaemon commands on/off/reboot by loging
into the BBB, and calling the equivalent acme scripts.

example: send "on" to DUT connected to probe 3

host-side command :
$> pduclient --daemon localhost --hostname acme0.local --command on --port 3

translated to:
acme: #> dut-switch-on 3

datasheet:https://baylibre.com/acme/#details
acme-wiki: http://wiki.baylibre.com/doku.php?id=acme:start
sigrok-wiki: https://sigrok.org/wiki/BayLibre_ACME

Signed-off-by: Marc Titinger <mtitinger@baylibre.com>