### PR TITLE
Add simple tutorial/evaluation pdu driver

### DIFF
--- a/etc/lavapdu/lavapdu.conf
+++ b/etc/lavapdu/lavapdu.conf
@@ -35,6 +35,10 @@
 		"password": "ubnt",
 		"sshport": 22,
 		"verify_hostkey": true
-	}
+	},
+        "127.0.0.1": {
+            "driver": "localcmdline"
+        }
+
     }
 }

--- a/lavapdu/drivers/localbase.py
+++ b/lavapdu/drivers/localbase.py
@@ -18,9 +18,33 @@
 #  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 #  MA 02110-1301, USA.
 
-from lavapdu.drivers.apc7952 import APC7952
-from lavapdu.drivers.apc9218 import APC9218
-from lavapdu.drivers.apc8959 import APC8959
-from lavapdu.drivers.apc9210 import APC9210
-from lavapdu.drivers.localcmdline import LocalCmdline
+import logging
+import pexpect
+from lavapdu.drivers.driver import PDUDriver
+import sys
+
+
+class LocalBase(PDUDriver):
+    connection = None
+
+    def __init__(self, hostname, settings):
+        self.hostname = hostname
+        logging.debug(settings)
+        self.settings = settings
+        super(LocalBase, self).__init__()
+
+    @classmethod
+    def accepts(cls, drivername):
+        return False
+
+    def port_interaction(self, command, port_number):
+        logging.debug("Running port_interaction from LocalBase")
+        self._port_interaction(command, port_number)
+
+    def _bombout(self):
+        logging.debug("Bombing out of driver: %s" % self.connection)
+        del(self)
+
+    def _cleanup(self):
+        logging.debug("Cleaning up driver: %s" % self.connection)
 

--- a/lavapdu/drivers/localcmdline.py
+++ b/lavapdu/drivers/localcmdline.py
@@ -1,0 +1,47 @@
+#! /usr/bin/python
+
+#  Copyright 2013 Linaro Limited
+#  Author Matt Hart <matthew.hart@linaro.org>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+
+import logging
+from subprocess import call
+from lavapdu.drivers.localbase import LocalBase
+
+
+class LocalCmdline(LocalBase):
+
+    @classmethod
+    def accepts(cls, drivername):
+        if drivername == "localcmdline":
+            return True
+        return False
+
+    def _port_interaction(self, command, port_number):
+
+        if command == "on":
+            print("Attempting local commandline ON control: %s port: %i" % (command, port_number))
+            # replace the call arguments below with your command line for the ON and OFF commands
+            # call(["relay-ctrl.py", str(port_number) , "POWER_ON"])
+
+        elif command == "off":
+            print("Attempting local commandline OFF control: %s port: %i" % (command, port_number))
+            # call(["relay-ctrl.py", str(port_number) , "POWER_OFF"])
+
+        else:
+            logging.debug("Unknown command!")
+

--- a/lavapdu/drivers/strategies.py
+++ b/lavapdu/drivers/strategies.py
@@ -18,9 +18,18 @@
 #  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 #  MA 02110-1301, USA.
 
-from lavapdu.drivers.apc7952 import APC7952
-from lavapdu.drivers.apc9218 import APC9218
-from lavapdu.drivers.apc8959 import APC8959
-from lavapdu.drivers.apc9210 import APC9210
+from lavapdu.drivers.apc7952 import APC7952  # pylint: disable=W0611
+from lavapdu.drivers.apc9218 import APC9218  # pylint: disable=W0611
+from lavapdu.drivers.apc8959 import APC8959  # pylint: disable=W0611
+from lavapdu.drivers.apc9210 import APC9210  # pylint: disable=W0611
+from lavapdu.drivers.ubiquity import Ubiquity3Port  # pylint: disable=W0611
+from lavapdu.drivers.ubiquity import Ubiquity6Port  # pylint: disable=W0611
 from lavapdu.drivers.localcmdline import LocalCmdline
+
+assert APC7952
+assert APC9218
+assert APC8959
+assert APC9210
+assert Ubiquity3Port
+assert Ubiquity6Port
 


### PR DESCRIPTION
For tutorial purposes and trivial evaluation installations (e.g. a laptop) adds a localbase class localbase.py for a non-networked pdu and a driver class localcmdline.py for a local pdu which is controlled by the command line. This could either be an Arduino with relays over USB serial or a RPi over ethernet. The actual command is dependent on whatever you need, so it's commented and replaced with a print in localcmdline.py. Entries are added in strategies.py and lavapdu.conf.
